### PR TITLE
Implement LBA48 PIO reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq ($(GIT_SHELL_EXIT),0)
 # Check if working dir is clean.
 GIT_STATUS := $(shell git status --porcelain)
 ifndef GIT_STATUS
-GIT_COMMIT_HASH := $(shell git rev-parse HEAD)
+GIT_COMMIT_HASH := $(shell git rev-parse --short HEAD)
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,27 @@
 #
 # Note by TT: the option "-mstructure-size-boundary=8" is necessary when compiling macpartitions.cc for the structs to get the correct sizes!
 
-# The next line gets the current svn revision.
-VERSION   = r$(shell sh -c "svnversion . | sed 's/[^0-9]//'")
+# Get the git hash, if the working directory is clean
+
+GIT_SHELL_EXIT := $(shell git status --porcelain 2> /dev/null >&2 ; echo $$?)
+
+# It can be non-zero when not in git repository or git is not installed.
+# It can happen when downloaded using github's "Download ZIP" option.
+ifeq ($(GIT_SHELL_EXIT),0)
+# Check if working dir is clean.
+GIT_STATUS := $(shell git status --porcelain)
+ifndef GIT_STATUS
+GIT_COMMIT_HASH := $(shell git rev-parse HEAD)
+endif
+endif
+
+ifdef GIT_COMMIT_HASH
+	VERSION   = $(GIT_COMMIT_HASH)
+else
+	VERSION   = 2.6
+endif
+
+$(info    VERSION is $(VERSION))
 
 CROSS    ?= arm-uclinux-elf-
 CC        = $(CROSS)gcc


### PR DESCRIPTION
Implement LBA48 PIO reads.

This allows LBAs to be read above the 128GB limit of LBA28. This fixes bad file reads on large drives when files are moved above the 128GB limit. This usually manifested as the ipodloader.conf file or kernels becoming "corrupt" after modifying them on a large iPod, because the host operating system moved it above the 128GB limit.