### PR TITLE
Add .bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 *.i*86
 *.x86_64
 *.hex
+*.bin
 
 # Debug files
 *.dSYM/


### PR DESCRIPTION
Minor change that adds *.bin to .gitignore, specifically to ignore loader.bin after a build.