### PR TITLE
Fat32 improvements

### DIFF
--- a/bootloader.h
+++ b/bootloader.h
@@ -1,12 +1,14 @@
 #ifndef _BOOTLOADER_H_
 #define _BOOTLOADER_H_
 
-typedef unsigned int   uint32;
-typedef unsigned short uint16;
-typedef unsigned char  uint8;
-typedef   signed int    int32;
-typedef   signed short  int16;
-typedef   signed char   int8;
+typedef unsigned long long uint64;
+typedef unsigned long      uint32;
+typedef unsigned short     uint16;
+typedef unsigned char      uint8;
+typedef   signed long long int64;
+typedef   signed long      int32;
+typedef   signed short     int16;
+typedef   signed char      int8;
 
 typedef unsigned long size_t;
 
@@ -50,5 +52,3 @@ typedef struct {
 
 
 #endif
-
-


### PR DESCRIPTION
This work was done while I was trying to diagnose the file corruption issue (that actually turned out to be the LBA28 issue already fixed). However, I feel the improvements warrant inclusion in the master codebase.

FAT type detection has been changed to use the more canonical cluster count method that is strongly suggested my Microsoft et al. This also detects FAT12 partitions and throws an error upon finding one.

Other code has also been cleaned up to use more standard techniques, and commented.

The typedefs for the project have been modified to make them actually guarantee the their size, regardless of target architecture (eg, use `long` instead of `int` for int32). Also added (u)int64 in case it it is needed in the future.

TODO: Still need to fix the file detection issues mentioned in the comment at the top of `fat32.c`