### PR TITLE
Fix 8.3 filename handling and improve LFN filename handling.

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,9 +1,2 @@
 TODO:
-* Make FAT32 use DOS-convention filenames instead of on-disk encoding
 * add support for piezo on PP5002 models (ipod_beep)
-
-Notes about TODOs:
-* Make FAT32 use DOS.....
-  Replace ' ' with 0x0, and do two strncmp() on each dirent, and
-  is should pretty much work already. Make case-insensitive for
-  niceness

--- a/minilibc.c
+++ b/minilibc.c
@@ -494,24 +494,34 @@ int mlc_strcasecmp(const char *s1,const char *s2) {
 	return( mlc_strncasecmp( s1,s2,max ) );
 }
 
-size_t mlc_strlcpy(char *dest,const char *src,size_t space)
+/*
+ * Copies a string from src to dest, and guarantees a null terminator at the end.
+ * The size argument indicates the allowed length of the dest buffer, and
+ * should include room for the null terminator.
+ */
+size_t mlc_strlcpy(char *dest,const char *src,size_t size)
 {
   size_t destlen = 0;
-  if (--space > 0) {
+  if (--size > 0) {
     do {
       if ((*dest++ = *src++) == 0) return destlen;
       destlen++;
-    } while (--space);
+    } while (--size);
     *dest++ = 0;
   }
   return destlen;
 }
 
-size_t mlc_strlcat(char *dest,const char *src,size_t count)
+/*
+ * Appends a string from src onto the end of dest, and guarantees a null terminator at the end.
+ * The size argument indicates the allowed length of the dest buffer, and
+ * should include room for the null terminator.
+ */
+size_t mlc_strlcat(char *dest,const char *src,size_t size)
 {
   size_t len = mlc_strlen(dest);
-  if (len >= count) return count;
-  return len + mlc_strlcpy (dest + len, src, count - len);
+  if (len >= size) return size;
+  return len + mlc_strlcpy (dest + len, src, size - len);
 }
 
 /* gcc emits code that calls memcpy() */


### PR DESCRIPTION
The previous 8.3 handling code contained an off-by-one error where a file with an 8.3
filename with a full 8 character name and full 3 character extension
would have the last character of its extension truncated.

For example, APPLE_OS.BIN would be truncated to APPLE_OS.BI

This prevents the file from being found via it's 8.3 name, and is the primary reason
loading apple_os.bin from disk functionality was broken.

As for why the file could not be found by its LFN as a fallback,
Windows NT from XP and up do not create any LFN entries for 8.3 compliant filenames that
have all lowercase or all uppercase names and all lowercase or all uppercase extensions.
This means that apple_os.bin, APPLE_OS.bin, apple_os.BIN, and APPLE_OS.BIN would all
suffer from this bug on Windows, but lowercase variants would mysteriously work if
created with the Linux VFAT driver. Additionally, names with non-8.3 compliant characters
would also have an LFN created on all systems, and would not suffer from this bug since the LFN would
still match.

This change also improves the way in which LFNs are handled.

It increases the maximum LFN size to 255 characters, and adds handling
of non-ASCII mappable UCS-2 characters.

It also fixes a few edge cases where a previous LFN could be considered
a candidate for a much later directory entry, and potentially used if
the checksum happened to match.

Additionally, removed the notes about DOS 8.3 filename comparisons since
doing such a thing no longer makes sense with LFN comparisons
implemented.

Added extra comments that document how things actually work.

Squashed commit messages:

Detect non-ASCII UCS-2 characters in LFNs and ignore LFNs containing them.

Ignore deleted LFN entries

Increase LFN buffer size to its technical maximum of 255

Improve LFN handling.

Increase LFN buffer size to 256 to handle the largest possible LFN +
NULL terminator.

Zero the entire LFN buffer upon finding the last logical (first
physical) 0x40 entry to avoid previous LFN entries remaining in the
buffer in certain edgecases.

Only copy values into the LFN buffer if the name is still possibly
valid (namegood).

Invalidate the LFN if it does not match up to an immediately following
normal directory entry, to avoid a previously copied LFN from incorrectly matching to a
later directory entry.

Add comments to document how LFN works.

Fix 8.3 filename construction.

Corrects the length passed to mlc_strlcat. The previous length was 1 too
short, meaning that a filename with a length of 8 would have its
extension truncated to only 2 characters long.

Possibly fixes apple_os.bin loading issue.

Fix casting issue and make ucs2cpy endian agnostic

Replace unmappable UCS-2 characters with '_' instead of '?'

Add note about small memory leak on file open

Update TODO list to remove FAT32 comparison note. This is not required since LFN filename lookups were added.

Remove note about file not found bug, since it's now fixed.