### PR TITLE
Bump version to 2.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,8 @@
 # Note by TT: the option "-mstructure-size-boundary=8" is necessary when compiling macpartitions.cc for the structs to get the correct sizes!
 
 # Get the git hash, if the working directory is clean
-
 GIT_SHELL_EXIT := $(shell git status --porcelain 2> /dev/null >&2 ; echo $$?)
-
-# It can be non-zero when not in git repository or git is not installed.
+# Return code can be non-zero when not in git repository or git is not installed.
 # It can happen when downloaded using github's "Download ZIP" option.
 ifeq ($(GIT_SHELL_EXIT),0)
 # Check if working dir is clean.
@@ -16,10 +14,11 @@ GIT_COMMIT_HASH := $(shell git rev-parse --short HEAD)
 endif
 endif
 
+# Suffix with "d" for development version, "b" for beta version
+VERSION   = 2.8
+
 ifdef GIT_COMMIT_HASH
-	VERSION   = $(GIT_COMMIT_HASH)
-else
-	VERSION   = 2.6
+	VERSION   := "$(VERSION) $(GIT_COMMIT_HASH)"
 endif
 
 $(info    VERSION is $(VERSION))

--- a/loader.c
+++ b/loader.c
@@ -11,7 +11,7 @@
 #include "config.h"
 #include "interrupts.h"
 
-#define LOADERNAME "iPL Loader 2.6 " VERSION // "d" stands for development version, "b" for beta version
+#define LOADERNAME "iPL " VERSION // VERSION is set in the Makefile
 
 static uint16 *framebuffer;
 static int orig_contrast;


### PR DESCRIPTION
Version 2.8 was selected to avoid collision with the 2.7 version of
the ipodloader2 binary that is floating around the internet.

Truncate loader name to just "iPL VERSION" to make room for the git
short hash included in VERSION. Move version number completely into the
Makefile.